### PR TITLE
Tolerate more clone errors; treat version dep mismatches as warnings instead of errors

### DIFF
--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -353,15 +353,12 @@ is_app_available(Config, App, VsnRegex, Path, _IsRaw = false) ->
                           [App, VsnRegex, App, Vsn, Path]),
                     case re:run(Vsn, VsnRegex, [{capture, none}]) of
                         match ->
-                            {Config2, {true, Path}};
+                            ok;
                         nomatch ->
-                            ?WARN("~s has version ~p; requested regex was ~s\n",
-                                  [AppFile, Vsn, VsnRegex]),
-                            {Config2,
-                             {false, {version_mismatch,
-                                      {AppFile,
-                                       {expected, VsnRegex}, {has, Vsn}}}}}
-                    end;
+                            ?ERROR("~s has version ~p; requested regex was ~s\n",
+                                  [AppFile, Vsn, VsnRegex])
+                    end,
+                    {Config2, {true, Path}};
                 {Config1, OtherApp} ->
                     ?WARN("~s has application id ~p; expected ~p\n",
                           [AppFile, OtherApp, App]),

--- a/src/rebar_deps.erl
+++ b/src/rebar_deps.erl
@@ -486,72 +486,19 @@ make_git_clone_error_handler(AppDir, Url, Attempt) ->
     MaxAttempts = 10,
     DelaySecondsBase = 10,
     fun (Command, {Rc, Output}) ->
-        case is_tolerable_git_clone_error(Output) of
+        ?ERROR("~s failed with error: ~w and output:~n~s~n",
+               [Command, Rc, Output]),
+        case Attempt =< MaxAttempts of
             true ->
-                ?ERROR("~s failed with error: ~w and output:~n~s~n",
-                       [Command, Rc, Output]),
-                case Attempt =< MaxAttempts of
-                    true ->
-                        % increase delay with each attempt
-                        DelaySeconds = DelaySecondsBase * Attempt,
-                        ?INFO("retrying in ~w seconds...~n", [DelaySeconds]),
-                        timer:sleep(DelaySeconds * 1000),
-                        git_clone(AppDir, Url, Attempt + 1);
-                    false ->
-                        ?ABORT("~s failed after ~w attempts~n", [Command, MaxAttempts])
-                end;
+                % increase delay with each attempt
+                DelaySeconds = DelaySecondsBase * Attempt,
+                ?INFO("retrying in ~w seconds...~n", [DelaySeconds]),
+                timer:sleep(DelaySeconds * 1000),
+                git_clone(AppDir, Url, Attempt + 1);
             false ->
-                ?ABORT("~s failed with error: ~w and output:~n~s~n",
-                       [Command, Rc, Output])
+                ?ABORT("~s failed after ~w attempts~n", [Command, MaxAttempts])
         end
     end.
-
-% we frequently see these errors when cloning from GitHub repositories
-is_tolerable_git_clone_error(Error) ->
-    % this one is typical when cloning git:// URLs
-    is_substring(Error, "fatal: unable to connect a socket (Connection timed out)") orelse
-
-    % usually followed by "fatal: The remote end hung up unexpectedly"
-    is_substring(Error, "Read from socket failed: Connection reset by peer") orelse
-    is_substring(Error, "Segmentation fault") orelse
-    is_substring(Error, "Write failed: Broken pipe") orelse
-
-    % these errors appears when cloning git@github.com URLs, e.g.:
-    %
-    %     "ssh: connect to host fs25 port 22: Connection timed out"
-    %     "ssh: connect to host fs25 port 22: No route to host"
-    %
-    % -- we should probably start using regexps...
-    %
-    % usually followed by "fatal: The remote end hung up unexpectedly"
-    is_substring(Error, " port 22: Connection timed out") orelse
-    is_substring(Error, " port 22: No route to host") orelse
-
-    % these errors appears when cloning https:// URLs
-    %
-    % usually followed by "fatal: The remote end hung up unexpectedly"
-    is_substring(Error, "error: RPC failed; result=22, HTTP code = 405") orelse
-    is_substring(Error, "error: RPC failed; result=7, HTTP code = 0") orelse
-
-    % usually followed by "fatal: HTTP request failed"
-    is_substring(Error, "error: The requested URL returned error: 403 while accessing") orelse
-    is_substring(Error, "error: The requested URL returned error: 503 while accessing") orelse
-    is_substring(Error, "error: The requested URL returned error: 502 while accessing") orelse
-
-    % usually followed by "fatal: The remote end hung up unexpectedly"
-    is_substring(Error, "ssh_exchange_identification: Connection closed by remote host") orelse
-    is_substring(Error, "ssh_exchange_identification: read: Connection reset by peer") orelse
-
-    % preceeded by "fatal: remote error: "
-    is_substring(Error, "Storage server temporarily offline. See http://status.github.com for GitHub system status.") orelse
-
-    % we've even seen that string printed alone witout any extra details
-    is_substring(Error, "fatal: The remote end hung up unexpectedly") orelse
-
-    false.
-
-is_substring(String, SubString) ->
-    string:str(String, SubString) =/= 0.
 
 update_source(Config, Dep) ->
     %% It's possible when updating a source, that a given dep does not have a

--- a/src/rebar_log.erl
+++ b/src/rebar_log.erl
@@ -49,10 +49,10 @@ set_level(Level) ->
 log(Level, Str, Args) ->
     {ok, LogLevel} = application:get_env(rebar, log_level),
     case should_log(LogLevel, Level) of
-        true ->
-            io:format(log_prefix(Level) ++ Str, Args);
         false ->
-            ok
+            ok;
+        Device ->
+            io:format(Device, log_prefix(Level) ++ Str, Args)
     end.
 
 default_level() -> error_level().
@@ -67,13 +67,13 @@ valid_level(Level) ->
 error_level() -> 0.
 debug_level() -> 3.
 
-should_log(debug, _)     -> true;
+should_log(debug, _)     -> standard_io;
 should_log(info, debug)  -> false;
-should_log(info, _)      -> true;
+should_log(info, _)      -> standard_io;
 should_log(warn, debug)  -> false;
 should_log(warn, info)   -> false;
-should_log(warn, _)      -> true;
-should_log(error, error) -> true;
+should_log(warn, _)      -> standard_error;
+should_log(error, error) -> standard_error;
 should_log(error, _)     -> false;
 should_log(_, _)         -> false.
 


### PR DESCRIPTION
@motobob 
Need to push to our ancient fork and then update our magic rebar. The artifact of this build is stored in svn branch of albuild and then goes to our build servers. Primarily needed for me to update mochiweb & webmachine versions in clyde (piqi-rpc is tied to older ones but I want to use newer ones as I suspect our clyde memory problems are related to older mochiweb).

Problem:
1) `rebar get-deps`; `rebar compile`, etc. aborts the build if a dependency exists but its version regex (if any) does not match the actual version, with no switch available to override this behavior. Worse, when recursively traversing dependencies, rebar makes no effort to try and fetch a version that will satisfy the version requirements of all dependent apps, even when this is actually possible. Besides, we use BOM to version dependencies and don't need rebar to enforce version consistency when fetching deps.
2) The amount of possible transient errors from public github is greater than one Lavrik can foresee :)

Solution:
1) "I know what I'm doing, Skywalker" -- print appropriate error messages on version mismatches to inform the user, but do not abort the build. Error and warning messages are now printed to stderr instead of stdout because some of our scripts (like `gen-bom`) do not expect status messages interspersed with the actual output.
2) Treat all `git clone` errors as retriable. (There is a limited number of retries, so a build that hits a non-transient error will still fail after about 10 minutes.)

Tested locally with al_node_scripts (make deps; make apply-release-bom; make; make deb rpm).
